### PR TITLE
Adding modified shr2_shl5_xor algorithm from Stealbit malware

### DIFF
--- a/algorithms/shr2_shl5_xor_init_c4d5a97a_stealbit.py
+++ b/algorithms/shr2_shl5_xor_init_c4d5a97a_stealbit.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+DESCRIPTION = "SHIFT RIGHT 2 and SHIFT LEFT 5 and XOR with initialization constant 0xc4d5a97a used in Stealbit malware."
+# Type can be either 'unsigned_int' (32bit) or 'unsigned_long' (64bit)
+TYPE = 'unsigned_int'
+# Test must match the exact has of the string 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+TEST_1 = 4099635895
+
+
+def hash(data):
+
+    # Initialize the hash value to 0xc4d5a97a
+    func_hash = 0xc4d5a97a
+
+    # Iterate through input string bytes and update the
+    # hash value
+    for b in data:
+        func_hash ^= ((func_hash >> 2) + ((func_hash << 5) + b)) & 0xFFFFFFFF
+
+    return func_hash


### PR DESCRIPTION
Implementing a slight modification of the existing _shr2_shl5_xor_ algorithm with the initialization constant 0xc4d5a97a observed in Stealbit version 1.1 malware samples.