### PR TITLE
64-bit SDBM hash function with constant 65599

### DIFF
--- a/algorithms/sdbm_65599_x64.py
+++ b/algorithms/sdbm_65599_x64.py
@@ -1,0 +1,10 @@
+DESCRIPTION = "The original SDBM hash function with the constant 65599. Used by Emotet malware."
+TYPE = 'unsigned_long'
+TEST_1 = 18326187587583583519
+
+
+def hash(data):
+    hsh = 0
+    for d in data:
+        hsh = d + 0x1003f * hsh
+    return hsh & 0xffffffffffffffff


### PR DESCRIPTION
Implementation of the original 64-bit SDBM hash function that used the constant 65599 (0x1003f).