### PR TITLE
Add alternative hashing seed for TOnePipeShell

### DIFF
--- a/algorithms/tonepipeshell.py
+++ b/algorithms/tonepipeshell.py
@@ -1,6 +1,6 @@
 # Created by Still Hsu <still@teamt5.org>
 
-DESCRIPTION = "TOnePipeShell hash with seed 0xC85E31"
+DESCRIPTION = "TOnePipeShell hash with seed 0xC85E31 (13131313)"
 TYPE = 'unsigned_int'
 TEST_1 = 3454880715
 

--- a/algorithms/tonepipeshell_alt.py
+++ b/algorithms/tonepipeshell_alt.py
@@ -1,0 +1,11 @@
+# Created by Still Hsu <still@teamt5.org>
+
+DESCRIPTION = "TOnePipeShell hash with seed 0x4E44CB31 (1313131313)"
+TYPE = 'unsigned_int'
+TEST_1 = 3702427595
+
+def hash(data):
+    out_hash = 0
+    for c in data:
+        out_hash = (c + 0x4E44CB31 * out_hash) & 0xffffffff
+    return out_hash


### PR DESCRIPTION
## Summary

This PR adds alternative hashing seed used by TOnePipeShell, as well as adding the int notation of the seed for anyone else that might stumble upon this number.