### PR TITLE
add mamon hash algorithm

### DIFF
--- a/algorithms/mamon_hash.py
+++ b/algorithms/mamon_hash.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+DESCRIPTION = "Custom hash used in mamon ransomware"
+TYPE = 'unsigned_int'
+TEST_1 = 3726794573 
+
+def hash(data):
+    hash_value = 0x42
+
+    for b in data:
+        hash_value = ((hash_value * 33) + b) & 0xFFFFFFFF  # Keep it 32-bit
+
+    return hash_value


### PR DESCRIPTION
A new hash algorithm for computing the hash of API names seen being used by mamon ransomware

Details:
Type: unsigned_int (32-bit)

Test Case: The hash of the string 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' was computed and validated.

Test Hash: TEST_1 = 3726794573

This new algorithm follows the guidelines outlined in the HashDB documentation and has been tested locally using pytest and checked for style with flake8.