### PR TITLE
add brc4-1-4-5 hash algorithm

### DIFF
--- a/algorithms/brc4_1_4_5.py
+++ b/algorithms/brc4_1_4_5.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+DESCRIPTION = "Hash algorithm used in BRC4 1.4.5"
+# Type can be either 'unsigned_int' (32bit) or 'unsigned_long' (64bit)
+TYPE = 'unsigned_int'
+# Test must match the exact hash of the string 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+TEST_1 = 3471553803
+
+
+def hash(data):
+    result = 0
+    for c in data:
+        temp = 2049 * result
+        temp |= 0x2800000 
+        temp += c
+        result = temp & 0xFFFFFFFF
+    
+    return result


### PR DESCRIPTION
This algorithm is the hash algorithm used in BRC4 1.4.5 in the offensive tool

Details:
Type: unsigned_int (32-bit)

Test Case: The hash of the string 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' was computed and validated.

Test Hash: TEST_1 = 3471553803

This new algorithm follows the guidelines outlined in the HashDB documentation and has been tested locally using pytest and checked for style with flake8.