### PR TITLE
Create djb2_seed5385_upper.py

### DIFF
--- a/algorithms/djb2_seed5385_upper.py
+++ b/algorithms/djb2_seed5385_upper.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+DESCRIPTION = "DJB2 variant with seed 5385 and uppercase normalization"
+TYPE = 'unsigned_int'
+TEST_1 = 2671650580
+
+
+def hash(data):
+    """Compute the API hash from byte input.
+    Returns a 32-bit unsigned int.
+    """
+    if isinstance(data, str):
+        data = data.encode('utf-8')
+
+    h = 5385
+    for b in data:
+        c = b
+        if c > 96:  # lowercase -> uppercase for ASCII
+            c -= 32
+        h = (h * 33 + c) & 0xFFFFFFFF
+    return h


### PR DESCRIPTION
Add DJB2 variant with seed 5385 and uppercase normalization

This PR introduces a new hashing algorithm to HashDB, based on a DJB2 variant observed in malware samples.

Seed value: 5385

Case handling: lowercase characters are normalized to uppercase before hashing

Type: unsigned_int (32-bit)

Test value: The hash of ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 produces 2671650580 (0x9F3E2714)

hash_sample: d406aef11220947f6fe579a1eb7ef44b57a695b7927c72122a5906704ea0d5c4

This algorithm has been seen in real-world malware for API hashing and string obfuscation. Adding it will allow analysts to more easily resolve hashes generated by this variant.