### PR TITLE
Create DJB2_Upper_3698.py

### DIFF
--- a/algorithms/DJB2_Upper_3698.py
+++ b/algorithms/DJB2_Upper_3698.py
@@ -1,0 +1,11 @@
+DESCRIPTION = "Custom hash algorithm using initial value 3698 with multiplier 33"
+TYPE = 'unsigned_int'
+# Hash of 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+TEST_1 = 3023272509
+
+def hash(data):
+    hash_value = 3698
+    for byte in data:
+        upper_char = byte if byte < 97 or byte > 122 else byte - 32
+        hash_value = (hash_value * 33 + upper_char) & 0xFFFFFFFF
+    return hash_value


### PR DESCRIPTION
Name: DJB2CaseInsensitive3698

Category: Custom / DJB2 variant

Type: unsigned_int

Multiplier: 33

Initial Value: 3698

Case Handling: Converts to uppercase

Example Hash: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' → 3023272509

sample: e787f64af048b9cb8a153a0759555785c8fd3ee1e8efbca312a29f2acb1e4011